### PR TITLE
Add playlist cleanup tool

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -31,6 +31,7 @@ import LongestSessions from "./scenes/LongestSessions";
 import AlbumStats from "./scenes/AlbumStats";
 import Benchmarks from "./scenes/Benchmarks";
 import ApiEndpointSetToFronted from "./scenes/Error/ApiEndpointSetToFronted";
+import PlaylistEdit from "./scenes/Tools/PlaylistEdit";
 
 function App() {
   const dark = useSelector(selectDarkMode);
@@ -184,15 +185,23 @@ function App() {
                   </PrivateRoute>
                 }
               />
-              <Route
-                path="/benchmarks"
-                element={
-                  <PrivateRoute>
-                    <Benchmarks />
-                  </PrivateRoute>
-                }
-              />
-            </Routes>
+                <Route
+                  path="/benchmarks"
+                  element={
+                    <PrivateRoute>
+                      <Benchmarks />
+                    </PrivateRoute>
+                  }
+                />
+                <Route
+                  path="/tools/playlists-edit"
+                  element={
+                    <PrivateRoute>
+                      <PlaylistEdit />
+                    </PrivateRoute>
+                  }
+                />
+              </Routes>
           </Layout>
         </BrowserRouter>
       </div>

--- a/apps/client/src/components/Layout/Sider/useLinks.tsx
+++ b/apps/client/src/components/Layout/Sider/useLinks.tsx
@@ -18,6 +18,8 @@ import {
   SpeedOutlined,
   OfflineShare,
   OfflineShareOutlined,
+  Edit,
+  EditOutlined,
 } from "@mui/icons-material";
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
@@ -97,6 +99,17 @@ export function useLinks() {
               restrict: "guest",
             },
           ]),
+        },
+        {
+          label: "Tools",
+          items: [
+            {
+              label: "Playlists edit",
+              link: "/tools/playlists-edit",
+              icon: <EditOutlined />,
+              iconOn: <Edit />,
+            },
+          ],
         },
         {
           label: "Settings",

--- a/apps/client/src/scenes/Tools/PlaylistEdit/PlaylistEdit.tsx
+++ b/apps/client/src/scenes/Tools/PlaylistEdit/PlaylistEdit.tsx
@@ -1,0 +1,55 @@
+import { Button, FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+import { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
+import Header from '../../../components/Header';
+import Text from '../../../components/Text';
+import { api } from '../../../services/apis/api';
+import { useAPI } from '../../../services/hooks/hooks';
+import { selectUser } from '../../../services/redux/modules/user/selector';
+import { Playlist } from '../../../services/redux/modules/playlist/types';
+import s from './index.module.css';
+
+export default function PlaylistEdit() {
+  const user = useSelector(selectUser);
+  const playlists = useAPI(api.getPlaylists);
+  const [selected, setSelected] = useState('');
+  const [removed, setRemoved] = useState<number | null>(null);
+
+  const remove = useCallback(async () => {
+    if (!selected) return;
+    const { data } = await api.removeLikedFromPlaylist(selected);
+    setRemoved(data.removed);
+  }, [selected]);
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div>
+      <Header title="Playlists edit" subtitle="Remove liked songs from a playlist" />
+      <div className={s.content}>
+        <FormControl fullWidth>
+          <InputLabel id="playlist">Select a playlist</InputLabel>
+          <Select
+            labelId="playlist"
+            label="Select a playlist"
+            value={selected}
+            onChange={ev => setSelected(ev.target.value)}>
+            {playlists?.map((pl: Playlist) => (
+              <MenuItem key={pl.id} value={pl.id}>
+                {pl.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Button variant="contained" disabled={!selected} onClick={remove}>
+          Remove liked songs
+        </Button>
+        {removed !== null && (
+          <Text element="div">Removed {removed} songs</Text>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/scenes/Tools/PlaylistEdit/index.module.css
+++ b/apps/client/src/scenes/Tools/PlaylistEdit/index.module.css
@@ -1,0 +1,7 @@
+.content {
+  padding: var(--page-padding);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 400px;
+}

--- a/apps/client/src/scenes/Tools/PlaylistEdit/index.ts
+++ b/apps/client/src/scenes/Tools/PlaylistEdit/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PlaylistEdit';

--- a/apps/client/src/services/apis/api.ts
+++ b/apps/client/src/services/apis/api.ts
@@ -534,6 +534,8 @@ export const api = {
     name: string | undefined,
     context: PlaylistContext,
   ) => post("/spotify/playlist/create", { playlistId: id, name, ...context }),
+  removeLikedFromPlaylist: (playlistId: string) =>
+    post<{ removed: number }>("/spotify/playlist/remove-liked", { playlistId }),
   getTrackDetails: (ids: string[]) => get<Track[]>(`/track/${ids.join(",")}`),
   getTrackStats: (id: string) =>
     get<TrackStatsResponse | { code: "NEVER_LISTENED" }>(`/track/${id}/stats`),

--- a/apps/server/src/routes/spotify.ts
+++ b/apps/server/src/routes/spotify.ts
@@ -580,3 +580,26 @@ router.post("/playlist/create", logged, withHttpClient, async (req, res) => {
   }
   res.status(204).end();
 });
+
+const removeLikedSchema = z.object({
+  playlistId: z.string(),
+});
+
+router.post("/playlist/remove-liked", logged, withHttpClient, async (req, res) => {
+  const { client } = req as LoggedRequest & SpotifyRequest;
+  const { playlistId } = validate(req.body, removeLikedSchema);
+
+  const likedTracks = await client.getUsersSavedTracks();
+  const playlistTracks = await client.getPlaylistTracks(playlistId);
+
+  const likedIds = new Set(likedTracks.map(t => t.track.id));
+  const toRemove = playlistTracks
+    .map(t => t.track.id)
+    .filter(id => likedIds.has(id));
+
+  if (toRemove.length > 0) {
+    await client.removePlaylistTracks(playlistId, toRemove);
+  }
+
+  res.status(200).send({ removed: toRemove.length });
+});

--- a/apps/server/src/routes/spotify.ts
+++ b/apps/server/src/routes/spotify.ts
@@ -241,7 +241,7 @@ router.get("/top/albums", isLoggedOrGuest, async (req, res) => {
 
 const collaborativeSchema = intervalPerSchema.merge(
   z.object({
-     otherIds: z.preprocess(
+    otherIds: z.preprocess(
       (val) => (typeof val === 'string' ? [val] : val), // If it's a string, wrap it in an array
       z.array(z.string()).min(1)
     ),
@@ -419,40 +419,40 @@ router.get(
 
     try {
       if (user.syncLikedSongsStatus === "inactive") {
-        res.status(400).json({ 
-          success: false, 
-          status: user.syncLikedSongsStatus, 
-          error: "Sync disabled" 
+        res.status(400).json({
+          success: false,
+          status: user.syncLikedSongsStatus,
+          error: "Sync disabled"
         });
         return;
-      } 
+      }
       else if (!user.syncLikedSongsPlaylistId && (user.syncLikedSongsStatus === "active" || user.syncLikedSongsStatus === "loading")) {
-        res.status(400).json({ 
-          success: false, 
-          status: user.syncLikedSongsStatus, 
-          error: "Sync failed, no playlist id found" 
+        res.status(400).json({
+          success: false,
+          status: user.syncLikedSongsStatus,
+          error: "Sync failed, no playlist id found"
         });
         return;
       } else if (user.syncLikedSongsStatus === "failed") {
-        res.status(500).json({ 
-          success: false, 
-          status: user.syncLikedSongsStatus, 
-          error: "Sync failed" 
+        res.status(500).json({
+          success: false,
+          status: user.syncLikedSongsStatus,
+          error: "Sync failed"
         });
         return;
       }
 
-      res.status(200).send({ 
-        success: true, 
-        status: user.syncLikedSongsStatus 
+      res.status(200).send({
+        success: true,
+        status: user.syncLikedSongsStatus
       });
       return;
     } catch (e) {
       logger.error(e);
-      res.status(500).json({ 
-        success: false, 
-        status: user.syncLikedSongsStatus, 
-        error: e.message 
+      res.status(500).json({
+        success: false,
+        status: user.syncLikedSongsStatus,
+        error: e.message
       });
       return;
     }
@@ -472,7 +472,7 @@ router.get("/playlist",
 
     const playlist = await client.getPlaylist(playlistId);
     res.status(200).send(playlist);
-});
+  });
 
 router.get("/playlists", logged, withHttpClient, async (req, res) => {
   const { client, user } = req as LoggedRequest & SpotifyRequest;


### PR DESCRIPTION
## Summary
- add Tools category with Playlists edit page
- show Tools in sidebar navigation
- remove liked songs from playlist via new API
- add frontend page to call new API

## Testing
- `yarn --cwd apps/client lint` *(fails: ESLint couldn't find a config)*
- `yarn --cwd apps/server lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68404b703b98833186174e12553eaed4