### PR TITLE
Add liked songs to playlist backups

### DIFF
--- a/apps/client/src/scenes/Tools/PlaylistBackup/index.module.css
+++ b/apps/client/src/scenes/Tools/PlaylistBackup/index.module.css
@@ -30,3 +30,10 @@
 .table tbody tr:nth-child(even) {
   background-color: var(--content-background);
 }
+
+@media screen and (min-width: 600px) {
+  .actions {
+    flex-direction: row;
+    align-items: center;
+  }
+}

--- a/apps/client/src/scenes/Tools/PlaylistBackup/playlistBackup.tsx
+++ b/apps/client/src/scenes/Tools/PlaylistBackup/playlistBackup.tsx
@@ -31,6 +31,17 @@ interface Subscription {
 export default function PlaylistBackup() {
   const user = useSelector(selectUser);
   const playlists = useAPI(api.getPlaylists);
+  const playlistsWithLiked = useMemo(() => {
+    if (!playlists || !user) return playlists;
+    const liked: Playlist = {
+      id: 'liked',
+      name: 'Liked Songs',
+      owner: { id: user.id },
+      images: [],
+      tracks: { total: 0, items: [] },
+    };
+    return [liked, ...playlists];
+  }, [playlists, user]);
   const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
   const [selected, setSelected] = useState<Playlist | null>(null);
   const [versionsMap, setVersionsMap] = useState<Record<string, { id: string; date: string; count: number }[]>>({});
@@ -78,7 +89,7 @@ export default function PlaylistBackup() {
     [subscriptions, refreshSubscriptions],
   );
 
-  const filtered = playlists ?? [];
+  const filtered = playlistsWithLiked ?? [];
 
   if (!user) return null;
 

--- a/apps/server/src/routes/spotify.ts
+++ b/apps/server/src/routes/spotify.ts
@@ -679,12 +679,20 @@ router.post(
         else songs.delete(c.songId);
       }
     }
-    const current = await client.getPlaylistTracks(playlistId);
+    const current =
+      playlistId === 'liked'
+        ? await client.getUsersSavedTracks()
+        : await client.getPlaylistTracks(playlistId);
     const currentIds = current.map(t => t.track.id);
     const toAdd = Array.from(songs).filter(id => !currentIds.includes(id));
     const toRemove = currentIds.filter(id => !songs.has(id));
-    if (toAdd.length) await client.addToPlaylist(playlistId, toAdd, 0);
-    if (toRemove.length) await client.removePlaylistTracks(playlistId, toRemove);
+    if (playlistId === 'liked') {
+      if (toAdd.length) await client.addUsersSavedTracks(toAdd);
+      if (toRemove.length) await client.removeUsersSavedTracks(toRemove);
+    } else {
+      if (toAdd.length) await client.addToPlaylist(playlistId, toAdd, 0);
+      if (toRemove.length) await client.removePlaylistTracks(playlistId, toRemove);
+    }
     await client.backupPlaylist(user, playlistId);
     res.status(200).json({ success: true });
   },


### PR DESCRIPTION
## Summary
- extend playlist backup route to handle liked songs restore
- allow selecting 'Liked Songs' playlist for backups
- tweak playlist backup layout for better mobile responsiveness

## Testing
- `yarn --cwd apps/client lint` *(fails: ESLint couldn't find eslint.config)*
- `yarn --cwd apps/server lint` *(fails: ESLint couldn't find eslint.config)*
- `yarn --cwd apps/client typecheck`
- `yarn --cwd apps/server build`


------
https://chatgpt.com/codex/tasks/task_e_685439e5c0d8833181a8e7d0b7e95da1