### PR TITLE
Add playlist vs liked songs comparison

### DIFF
--- a/apps/client/src/scenes/Tools/PlaylistEdit/PlaylistEdit.tsx
+++ b/apps/client/src/scenes/Tools/PlaylistEdit/PlaylistEdit.tsx
@@ -3,6 +3,8 @@ import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import Header from '../../../components/Header';
 import Text from '../../../components/Text';
+import InlineTrack from '../../../components/InlineTrack';
+import { Track } from '../../../services/types';
 import { api } from '../../../services/apis/api';
 import { useAPI } from '../../../services/hooks/hooks';
 import { selectUser } from '../../../services/redux/modules/user/selector';
@@ -14,11 +16,21 @@ export default function PlaylistEdit() {
   const playlists = useAPI(api.getPlaylists);
   const [selected, setSelected] = useState('');
   const [success, setSuccess] = useState<boolean | null>(null);
+  const [diff, setDiff] = useState<{
+    onlyInPlaylist: Track[];
+    onlyInLiked: Track[];
+  } | null>(null);
 
   const remove = useCallback(async () => {
     if (!selected) return;
     const { data } = await api.removeLikedSongsFromPlaylist(selected);
     setSuccess(data.success);
+  }, [selected]);
+
+  const compare = useCallback(async () => {
+    if (!selected) return;
+    const { data } = await api.comparePlaylistWithLiked(selected);
+    setDiff(data);
   }, [selected]);
 
   if (!user) {
@@ -46,8 +58,35 @@ export default function PlaylistEdit() {
         <Button variant="contained" disabled={!selected} onClick={remove}>
           Remove liked songs
         </Button>
+        <Button variant="contained" disabled={!selected} onClick={compare}>
+          Compare with liked songs
+        </Button>
         {success !== null && (
           <Text element="div">Success: {success.toString()}</Text>
+        )}
+        {diff && (
+          <div className={s.differences}>
+            <div>
+              <Text element="h3">Only in playlist</Text>
+              <ul className={s.list}>
+                {diff.onlyInPlaylist.map(track => (
+                  <li key={track.id}>
+                    <InlineTrack track={track} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <Text element="h3">Liked but not in playlist</Text>
+              <ul className={s.list}>
+                {diff.onlyInLiked.map(track => (
+                  <li key={track.id}>
+                    <InlineTrack track={track} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/apps/client/src/scenes/Tools/PlaylistEdit/index.module.css
+++ b/apps/client/src/scenes/Tools/PlaylistEdit/index.module.css
@@ -5,3 +5,20 @@
   gap: 16px;
   max-width: 400px;
 }
+
+.differences {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 600px) {
+  .differences {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}

--- a/apps/client/src/services/apis/api.ts
+++ b/apps/client/src/services/apis/api.ts
@@ -536,6 +536,11 @@ export const api = {
   ) => post("/spotify/playlist/create", { playlistId: id, name, ...context }),
   removeLikedSongsFromPlaylist: (playlistId: string) =>
     post<{ success: boolean }>("/spotify/playlist/remove-likedsongs", { playlistId }),
+  comparePlaylistWithLiked: (playlistId: string) =>
+    get<{ onlyInPlaylist: Track[]; onlyInLiked: Track[] }>(
+      "/spotify/playlist/compare-likedsongs",
+      { playlistId },
+    ),
   getTrackDetails: (ids: string[]) => get<Track[]>(`/track/${ids.join(",")}`),
   getTrackStats: (id: string) =>
     get<TrackStatsResponse | { code: "NEVER_LISTENED" }>(`/track/${id}/stats`),

--- a/apps/client/src/services/redux/modules/user/thunk.ts
+++ b/apps/client/src/services/redux/modules/user/thunk.ts
@@ -4,6 +4,7 @@ import { myAsyncThunk } from "../../tools";
 import { alertMessage } from "../message/reducer";
 import { selectIsPublic } from "./selector";
 import { DarkModeType, SyncLikedSongsResponse, SyncLikedSongsStatusResponse, User } from "./types";
+import { Track } from "../../../types";
 
 export const checkLogged = myAsyncThunk<User | null, void>(
   "@user/checklogged",
@@ -241,3 +242,23 @@ export const removeLikedSongs = myAsyncThunk<boolean, string>(
     }
   },
 );
+
+export const comparePlaylistWithLiked = myAsyncThunk<
+  { onlyInPlaylist: Track[]; onlyInLiked: Track[] } | null,
+  string
+>("@user/compare-likedsongs", async (playlistId, tapi) => {
+  try {
+    const resp = await api.comparePlaylistWithLiked(playlistId);
+    await tapi.dispatch(checkLogged());
+    return resp.data;
+  } catch (e) {
+    console.error(e);
+    tapi.dispatch(
+      alertMessage({
+        level: "error",
+        message: "Could not compare playlist with liked songs",
+      }),
+    );
+    return null;
+  }
+});

--- a/apps/server/src/routes/spotify.ts
+++ b/apps/server/src/routes/spotify.ts
@@ -607,6 +607,35 @@ router.post("/playlist/remove-likedsongs", logged, withHttpClient, async (req, r
   });
 });
 
+const compareLikedSchema = z.object({
+  playlistId: z.string(),
+});
+
+router.get(
+  "/playlist/compare-likedsongs",
+  logged,
+  withHttpClient,
+  async (req, res) => {
+    const { client } = req as LoggedRequest & SpotifyRequest;
+    const { playlistId } = validate(req.query, compareLikedSchema);
+
+    const playlistTracks = await client.getPlaylistTracks(playlistId);
+    const likedTracks = await client.getUsersSavedTracks();
+
+    const likedSet = new Set(likedTracks.map(t => t.track.id));
+    const playlistSet = new Set(playlistTracks.map(t => t.track.id));
+
+    const onlyInPlaylist = playlistTracks
+      .filter(t => !likedSet.has(t.track.id))
+      .map(t => t.track);
+    const onlyInLiked = likedTracks
+      .filter(t => !playlistSet.has(t.track.id))
+      .map(t => t.track);
+
+    res.status(200).send({ onlyInPlaylist, onlyInLiked });
+  },
+);
+
 
 const playlistBackupSubscriptionSchema = z.object({
   playlistId: z.string(),


### PR DESCRIPTION
## Summary
- expose new `/spotify/playlist/compare-likedsongs` API endpoint
- expose client API helper for comparing playlist vs liked songs
- extend playlist edit page to compare playlist with liked songs and show differences
- style new diff list responsively
- add redux thunk for comparison endpoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685946cf1cc483318cea6a0ff05aa1d9