### PR TITLE
Add playlist vs liked songs comparison

### DIFF
--- a/apps/client/src/scenes/Tools/PlaylistEdit/PlaylistEdit.tsx
+++ b/apps/client/src/scenes/Tools/PlaylistEdit/PlaylistEdit.tsx
@@ -1,8 +1,10 @@
 import { Button, FormControl, InputLabel, MenuItem, Select } from '@mui/material';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import Header from '../../../components/Header';
 import Text from '../../../components/Text';
+import InlineTrack from '../../../components/InlineTrack';
+import { Track } from '../../../services/types';
 import { api } from '../../../services/apis/api';
 import { useAPI } from '../../../services/hooks/hooks';
 import { selectUser } from '../../../services/redux/modules/user/selector';
@@ -14,12 +16,44 @@ export default function PlaylistEdit() {
   const playlists = useAPI(api.getPlaylists);
   const [selected, setSelected] = useState('');
   const [success, setSuccess] = useState<boolean | null>(null);
+  const [diff, setDiff] = useState<{
+    onlyInPlaylist: Track[];
+    onlyInLiked: Track[];
+  } | null>(null);
+  const [loadingCompare, setLoadingCompare] = useState(false);
+  const [compareId, setCompareId] = useState<string | null>(null);
 
   const remove = useCallback(async () => {
     if (!selected) return;
     const { data } = await api.removeLikedSongsFromPlaylist(selected);
     setSuccess(data.success);
   }, [selected]);
+
+  const compare = useCallback(async () => {
+    if (!selected) return;
+    setDiff(null);
+    setLoadingCompare(true);
+    const { data } = await api.startComparePlaylistWithLiked(selected);
+    setCompareId(data.id);
+  }, [selected]);
+
+  useEffect(() => {
+    if (!compareId) return;
+    const interval = setInterval(async () => {
+      const { data } = await api.getComparePlaylistWithLikedStatus(compareId);
+      if (data.status === 'done') {
+        setDiff(data.result ?? null);
+        setLoadingCompare(false);
+        setCompareId(null);
+        clearInterval(interval);
+      } else if (data.status === 'error') {
+        setLoadingCompare(false);
+        setCompareId(null);
+        clearInterval(interval);
+      }
+    }, 3000);
+    return () => clearInterval(interval);
+  }, [compareId]);
 
   if (!user) {
     return null;
@@ -46,8 +80,40 @@ export default function PlaylistEdit() {
         <Button variant="contained" disabled={!selected} onClick={remove}>
           Remove liked songs
         </Button>
+        <Button
+          variant="contained"
+          disabled={!selected || loadingCompare}
+          onClick={compare}
+        >
+          Compare with liked songs
+        </Button>
+        {loadingCompare && <Text element="div">Comparing...</Text>}
         {success !== null && (
           <Text element="div">Success: {success.toString()}</Text>
+        )}
+        {diff && (
+          <div className={s.differences}>
+            <div>
+              <Text element="h3">Only in playlist</Text>
+              <ul className={s.list}>
+                {diff.onlyInPlaylist.map(track => (
+                  <li key={track.id}>
+                    <InlineTrack track={track} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <Text element="h3">Liked but not in playlist</Text>
+              <ul className={s.list}>
+                {diff.onlyInLiked.map(track => (
+                  <li key={track.id}>
+                    <InlineTrack track={track} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
         )}
       </div>
     </div>

--- a/apps/client/src/scenes/Tools/PlaylistEdit/index.module.css
+++ b/apps/client/src/scenes/Tools/PlaylistEdit/index.module.css
@@ -5,3 +5,20 @@
   gap: 16px;
   max-width: 400px;
 }
+
+.differences {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 600px) {
+  .differences {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}

--- a/apps/client/src/services/apis/api.ts
+++ b/apps/client/src/services/apis/api.ts
@@ -536,6 +536,18 @@ export const api = {
   ) => post("/spotify/playlist/create", { playlistId: id, name, ...context }),
   removeLikedSongsFromPlaylist: (playlistId: string) =>
     post<{ success: boolean }>("/spotify/playlist/remove-likedsongs", { playlistId }),
+  startComparePlaylistWithLiked: (playlistId: string) =>
+    post<{ id: string }>("/spotify/playlist/compare-likedsongs/start", { playlistId }),
+  getComparePlaylistWithLikedStatus: (id: string) =>
+    get<{ status: string; result?: { onlyInPlaylist: Track[]; onlyInLiked: Track[] } }>(
+      "/spotify/playlist/compare-likedsongs/status",
+      { id },
+    ),
+  comparePlaylistWithLiked: (playlistId: string) =>
+    get<{ onlyInPlaylist: Track[]; onlyInLiked: Track[] }>(
+      "/spotify/playlist/compare-likedsongs",
+      { playlistId },
+    ),
   getTrackDetails: (ids: string[]) => get<Track[]>(`/track/${ids.join(",")}`),
   getTrackStats: (id: string) =>
     get<TrackStatsResponse | { code: "NEVER_LISTENED" }>(`/track/${id}/stats`),

--- a/apps/client/src/services/redux/modules/user/thunk.ts
+++ b/apps/client/src/services/redux/modules/user/thunk.ts
@@ -4,6 +4,7 @@ import { myAsyncThunk } from "../../tools";
 import { alertMessage } from "../message/reducer";
 import { selectIsPublic } from "./selector";
 import { DarkModeType, SyncLikedSongsResponse, SyncLikedSongsStatusResponse, User } from "./types";
+import { Track } from "../../../types";
 
 export const checkLogged = myAsyncThunk<User | null, void>(
   "@user/checklogged",
@@ -241,3 +242,32 @@ export const removeLikedSongs = myAsyncThunk<boolean, string>(
     }
   },
 );
+
+export const comparePlaylistWithLiked = myAsyncThunk<
+  { onlyInPlaylist: Track[]; onlyInLiked: Track[] } | null,
+  string
+>("@user/compare-likedsongs", async (playlistId, tapi) => {
+  try {
+    const start = await api.startComparePlaylistWithLiked(playlistId);
+    const id = start.data.id;
+    let status;
+    do {
+      await new Promise(res => setTimeout(res, 2000));
+      status = await api.getComparePlaylistWithLikedStatus(id);
+    } while (status.data.status === "loading");
+    await tapi.dispatch(checkLogged());
+    if (status.data.status === "done" && status.data.result) {
+      return status.data.result;
+    }
+    return null;
+  } catch (e) {
+    console.error(e);
+    tapi.dispatch(
+      alertMessage({
+        level: "error",
+        message: "Could not compare playlist with liked songs",
+      }),
+    );
+    return null;
+  }
+});

--- a/apps/server/src/routes/spotify.ts
+++ b/apps/server/src/routes/spotify.ts
@@ -45,8 +45,17 @@ import {
   getBackupsUntil as getPlaylistBackupsUntil,
 } from "../database/queries/playlistBackup";
 import { SpotifyAPI } from "../tools/apis/spotifyApi";
+import { v4 as uuidv4 } from "uuid";
 
 export const router = Router();
+
+const compareJobs: Record<
+  string,
+  {
+    status: "loading" | "done" | "error";
+    result?: { onlyInPlaylist: any[]; onlyInLiked: any[] };
+  }
+> = {};
 
 const playSchema = z.object({
   id: z.string(),
@@ -606,6 +615,71 @@ router.post("/playlist/remove-likedsongs", logged, withHttpClient, async (req, r
     success: true
   });
 });
+
+const compareLikedSchema = z.object({
+  playlistId: z.string(),
+});
+
+const compareLikedStatusSchema = z.object({
+  id: z.string(),
+});
+
+router.post(
+  "/playlist/compare-likedsongs/start",
+  logged,
+  withHttpClient,
+  async (req, res) => {
+    const { client } = req as LoggedRequest & SpotifyRequest;
+    const { playlistId } = validate(req.body, compareLikedSchema);
+
+    const id = uuidv4();
+    compareJobs[id] = { status: "loading" };
+
+    (async () => {
+      try {
+        const playlistTracks = await client.getPlaylistTracks(playlistId);
+        const likedTracks = await client.getUsersSavedTracks();
+
+        const likedSet = new Set(likedTracks.map(t => t.track.id));
+        const playlistSet = new Set(playlistTracks.map(t => t.track.id));
+
+        const onlyInPlaylist = playlistTracks
+          .filter(t => !likedSet.has(t.track.id))
+          .map(t => t.track);
+        const onlyInLiked = likedTracks
+          .filter(t => !playlistSet.has(t.track.id))
+          .map(t => t.track);
+
+        compareJobs[id] = {
+          status: "done",
+          result: { onlyInPlaylist, onlyInLiked },
+        };
+      } catch (e) {
+        logger.error(e);
+        compareJobs[id] = { status: "error" };
+      }
+      setTimeout(() => {
+        delete compareJobs[id];
+      }, 1000 * 60 * 5);
+    })().catch(logger.error);
+
+    res.status(202).send({ id });
+  },
+);
+
+router.get(
+  "/playlist/compare-likedsongs/status",
+  logged,
+  async (req, res) => {
+    const { id } = validate(req.query, compareLikedStatusSchema);
+    const job = compareJobs[id];
+    if (!job) {
+      res.status(404).end();
+      return;
+    }
+    res.status(200).send(job);
+  },
+);
 
 
 const playlistBackupSubscriptionSchema = z.object({


### PR DESCRIPTION
## Summary
- expose new `/spotify/playlist/compare-likedsongs/start` endpoint to run playlist/liked songs diff async
- expose `/spotify/playlist/compare-likedsongs/status` endpoint to poll for diff result
- add client helpers for starting and checking playlist diff
- implement thunk to poll until diff is ready
- update playlist edit page to poll and display diff once done

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685946cf1cc483318cea6a0ff05aa1d9