### PR TITLE
Add playlist comparison tool

### DIFF
--- a/apps/client/src/scenes/Tools/PlaylistEdit/PlaylistEdit.tsx
+++ b/apps/client/src/scenes/Tools/PlaylistEdit/PlaylistEdit.tsx
@@ -1,4 +1,12 @@
-import { Button, FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+import {
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Autocomplete,
+  TextField,
+} from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import Header from '../../../components/Header';
@@ -15,13 +23,18 @@ export default function PlaylistEdit() {
   const user = useSelector(selectUser);
   const playlists = useAPI(api.getPlaylists);
   const [selected, setSelected] = useState('');
+  const [first, setFirst] = useState<Playlist | null>(null);
+  const [second, setSecond] = useState<Playlist | null>(null);
   const [success, setSuccess] = useState<boolean | null>(null);
   const [diff, setDiff] = useState<{
-    onlyInPlaylist: Track[];
-    onlyInLiked: Track[];
+    onlyInFirst: Track[];
+    onlyInSecond: Track[];
   } | null>(null);
   const [loadingCompare, setLoadingCompare] = useState(false);
   const [compareId, setCompareId] = useState<string | null>(null);
+
+  const likedOption = { id: 'liked', name: 'Liked songs' } as unknown as Playlist;
+  const playlistOptions = (playlists ?? []).concat(likedOption);
 
   const remove = useCallback(async () => {
     if (!selected) return;
@@ -30,17 +43,17 @@ export default function PlaylistEdit() {
   }, [selected]);
 
   const compare = useCallback(async () => {
-    if (!selected) return;
+    if (!first || !second) return;
     setDiff(null);
     setLoadingCompare(true);
-    const { data } = await api.startComparePlaylistWithLiked(selected);
+    const { data } = await api.startComparePlaylists(first.id, second.id);
     setCompareId(data.id);
-  }, [selected]);
+  }, [first, second]);
 
   useEffect(() => {
     if (!compareId) return;
     const interval = setInterval(async () => {
-      const { data } = await api.getComparePlaylistWithLikedStatus(compareId);
+      const { data } = await api.getComparePlaylistsStatus(compareId);
       if (data.status === 'done') {
         setDiff(data.result ?? null);
         setLoadingCompare(false);
@@ -80,39 +93,65 @@ export default function PlaylistEdit() {
         <Button variant="contained" disabled={!selected} onClick={remove}>
           Remove liked songs
         </Button>
-        <Button
-          variant="contained"
-          disabled={!selected || loadingCompare}
-          onClick={compare}
-        >
-          Compare with liked songs
-        </Button>
+        <div className={s.compareInputs}>
+          <Autocomplete
+            fullWidth
+            options={playlistOptions}
+            getOptionLabel={(pl: Playlist) => pl.name}
+            value={first}
+            onChange={(ev, val) => setFirst(val)}
+            renderInput={params => <TextField {...params} label="First playlist" />}
+            filterOptions={(options) =>
+              options.filter(o => !second || o.id !== second.id)
+            }
+          />
+          <Autocomplete
+            fullWidth
+            options={playlistOptions}
+            getOptionLabel={(pl: Playlist) => pl.name}
+            value={second}
+            onChange={(ev, val) => setSecond(val)}
+            renderInput={params => <TextField {...params} label="Second playlist" />}
+            filterOptions={(options) =>
+              options.filter(o => !first || o.id !== first.id)
+            }
+          />
+          <Button
+            variant="contained"
+            disabled={!first || !second || loadingCompare}
+            onClick={compare}
+          >
+            Compare playlists
+          </Button>
+        </div>
         {loadingCompare && <Text element="div">Comparing...</Text>}
         {success !== null && (
           <Text element="div">Success: {success.toString()}</Text>
         )}
-        {diff && (
-          <div className={s.differences}>
-            <div>
-              <Text element="h3">Only in playlist</Text>
-              <ul className={s.list}>
-                {diff.onlyInPlaylist.map(track => (
-                  <li key={track.id}>
-                    <InlineTrack track={track} />
-                  </li>
+        {diff && first && second && (
+          <div className={s.tableContainer}>
+            <table className={s.table}>
+              <thead>
+                <tr>
+                  <th>Only in {first.name}</th>
+                  <th>Only in {second.name}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Array.from({
+                  length: Math.max(diff.onlyInFirst.length, diff.onlyInSecond.length),
+                }).map((_, idx) => (
+                  <tr key={idx}>
+                    <td>
+                      {diff.onlyInFirst[idx] && <InlineTrack track={diff.onlyInFirst[idx]} />}
+                    </td>
+                    <td>
+                      {diff.onlyInSecond[idx] && <InlineTrack track={diff.onlyInSecond[idx]} />}
+                    </td>
+                  </tr>
                 ))}
-              </ul>
-            </div>
-            <div>
-              <Text element="h3">Liked but not in playlist</Text>
-              <ul className={s.list}>
-                {diff.onlyInLiked.map(track => (
-                  <li key={track.id}>
-                    <InlineTrack track={track} />
-                  </li>
-                ))}
-              </ul>
-            </div>
+              </tbody>
+            </table>
           </div>
         )}
       </div>

--- a/apps/client/src/scenes/Tools/PlaylistEdit/index.module.css
+++ b/apps/client/src/scenes/Tools/PlaylistEdit/index.module.css
@@ -6,19 +6,30 @@
   max-width: 400px;
 }
 
-.differences {
-  display: grid;
+.compareInputs {
+  display: flex;
+  flex-direction: column;
   gap: 16px;
 }
 
 @media (min-width: 600px) {
-  .differences {
-    grid-template-columns: 1fr 1fr;
+  .compareInputs {
+    flex-direction: row;
+    align-items: center;
   }
 }
 
-.list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.tableContainer {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 8px;
+  border-bottom: 1px solid #ddd;
 }

--- a/apps/client/src/services/apis/api.ts
+++ b/apps/client/src/services/apis/api.ts
@@ -539,14 +539,24 @@ export const api = {
   startComparePlaylistWithLiked: (playlistId: string) =>
     post<{ id: string }>("/spotify/playlist/compare-likedsongs/start", { playlistId }),
   getComparePlaylistWithLikedStatus: (id: string) =>
-    get<{ status: string; result?: { onlyInPlaylist: Track[]; onlyInLiked: Track[] } }>(
+    get<{ status: string; result?: { onlyInFirst: Track[]; onlyInSecond: Track[] } }>(
       "/spotify/playlist/compare-likedsongs/status",
       { id },
     ),
   comparePlaylistWithLiked: (playlistId: string) =>
-    get<{ onlyInPlaylist: Track[]; onlyInLiked: Track[] }>(
+    get<{ onlyInFirst: Track[]; onlyInSecond: Track[] }>(
       "/spotify/playlist/compare-likedsongs",
       { playlistId },
+    ),
+  startComparePlaylists: (first: string, second: string) =>
+    post<{ id: string }>("/spotify/playlist/compare/start", {
+      playlistIdA: first,
+      playlistIdB: second,
+    }),
+  getComparePlaylistsStatus: (id: string) =>
+    get<{ status: string; result?: { onlyInFirst: Track[]; onlyInSecond: Track[] } }>(
+      "/spotify/playlist/compare/status",
+      { id },
     ),
   getTrackDetails: (ids: string[]) => get<Track[]>(`/track/${ids.join(",")}`),
   getTrackStats: (id: string) =>

--- a/apps/client/src/services/redux/modules/user/thunk.ts
+++ b/apps/client/src/services/redux/modules/user/thunk.ts
@@ -244,7 +244,7 @@ export const removeLikedSongs = myAsyncThunk<boolean, string>(
 );
 
 export const comparePlaylistWithLiked = myAsyncThunk<
-  { onlyInPlaylist: Track[]; onlyInLiked: Track[] } | null,
+  { onlyInFirst: Track[]; onlyInSecond: Track[] } | null,
   string
 >("@user/compare-likedsongs", async (playlistId, tapi) => {
   try {
@@ -266,6 +266,35 @@ export const comparePlaylistWithLiked = myAsyncThunk<
       alertMessage({
         level: "error",
         message: "Could not compare playlist with liked songs",
+      }),
+    );
+    return null;
+  }
+});
+
+export const comparePlaylists = myAsyncThunk<
+  { onlyInFirst: Track[]; onlyInSecond: Track[] } | null,
+  { first: string; second: string }
+>("@user/compare-playlists", async ({ first, second }, tapi) => {
+  try {
+    const start = await api.startComparePlaylists(first, second);
+    const id = start.data.id;
+    let status;
+    do {
+      await new Promise(res => setTimeout(res, 2000));
+      status = await api.getComparePlaylistsStatus(id);
+    } while (status.data.status === "loading");
+    await tapi.dispatch(checkLogged());
+    if (status.data.status === "done" && status.data.result) {
+      return status.data.result;
+    }
+    return null;
+  } catch (e) {
+    console.error(e);
+    tapi.dispatch(
+      alertMessage({
+        level: "error",
+        message: "Could not compare playlists",
       }),
     );
     return null;

--- a/apps/server/src/routes/spotify.ts
+++ b/apps/server/src/routes/spotify.ts
@@ -49,11 +49,16 @@ import { v4 as uuidv4 } from "uuid";
 
 export const router = Router();
 
+interface CompareResult {
+  onlyInFirst: any[];
+  onlyInSecond: any[];
+}
+
 const compareJobs: Record<
   string,
   {
     status: "loading" | "done" | "error";
-    result?: { onlyInPlaylist: any[]; onlyInLiked: any[] };
+    result?: CompareResult;
   }
 > = {};
 
@@ -652,7 +657,10 @@ router.post(
 
         compareJobs[id] = {
           status: "done",
-          result: { onlyInPlaylist, onlyInLiked },
+          result: {
+            onlyInFirst: onlyInPlaylist,
+            onlyInSecond: onlyInLiked,
+          },
         };
       } catch (e) {
         logger.error(e);
@@ -672,6 +680,77 @@ router.get(
   logged,
   async (req, res) => {
     const { id } = validate(req.query, compareLikedStatusSchema);
+    const job = compareJobs[id];
+    if (!job) {
+      res.status(404).end();
+      return;
+    }
+    res.status(200).send(job);
+  },
+);
+
+const comparePlaylistsSchema = z.object({
+  playlistIdA: z.string(),
+  playlistIdB: z.string(),
+});
+
+const comparePlaylistsStatusSchema = z.object({
+  id: z.string(),
+});
+
+router.post(
+  "/playlist/compare/start",
+  logged,
+  withHttpClient,
+  async (req, res) => {
+    const { client } = req as LoggedRequest & SpotifyRequest;
+    const { playlistIdA, playlistIdB } = validate(req.body, comparePlaylistsSchema);
+
+    const id = uuidv4();
+    compareJobs[id] = { status: "loading" };
+
+    (async () => {
+      const getTracks = async (plId: string) => {
+        if (plId === "liked") {
+          const liked = await client.getUsersSavedTracks();
+          return liked.map(t => t.track);
+        }
+        const tracks = await client.getPlaylistTracks(plId);
+        return tracks.map(t => t.track);
+      };
+
+      try {
+        const tracksA = await getTracks(playlistIdA);
+        const tracksB = await getTracks(playlistIdB);
+
+        const setA = new Set(tracksA.map(t => t.id));
+        const setB = new Set(tracksB.map(t => t.id));
+
+        const onlyInA = tracksA.filter(t => !setB.has(t.id));
+        const onlyInB = tracksB.filter(t => !setA.has(t.id));
+
+        compareJobs[id] = {
+          status: "done",
+          result: { onlyInFirst: onlyInA, onlyInSecond: onlyInB },
+        };
+      } catch (e) {
+        logger.error(e);
+        compareJobs[id] = { status: "error" };
+      }
+      setTimeout(() => {
+        delete compareJobs[id];
+      }, 1000 * 60 * 5);
+    })().catch(logger.error);
+
+    res.status(202).send({ id });
+  },
+);
+
+router.get(
+  "/playlist/compare/status",
+  logged,
+  async (req, res) => {
+    const { id } = validate(req.query, comparePlaylistsStatusSchema);
     const job = compareJobs[id];
     if (!job) {
       res.status(404).end();


### PR DESCRIPTION
## Summary
- extend compare utilities to handle playlist vs playlist
- include liked songs as an option
- display differences in a table

## Testing
- `yarn --cwd apps/client typecheck` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685c0ce42d8c83319153fe7fd649e282